### PR TITLE
Migrate backend URL to env variable and point to Render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import './App.css';
 
 function App() {
 
-  const baseURL = "https://epic-beer-run.herokuapp.com"
+  const baseURL = process.env.REACT_APP_BASE_URL
   const [selectedState, setSelectedState] = useState("")
   const [breweryDB, setBreweryDB] = useState([])
   const [coordinates, setCoordinates] = useState([])


### PR DESCRIPTION
Replaces hardcoded Heroku URL with REACT_APP_BASE_URL env variable pointing to the new Render deployment. Adds .env to .gitignore.